### PR TITLE
feat(ci): Improve Python concurrency + Python 3.13

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -24,13 +24,18 @@ jobs:
   build:
     # This workflow runs on the latest version of Ubuntu
     runs-on: ubuntu-latest
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.python-version }}
+      cancel-in-progress: true
+    
     strategy:
       fail-fast: false
       matrix:
         # Python versions to test against
         # These are all the main versions of Python that are currently supported 
         # excluding 3.8
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request includes an update to the GitHub Actions workflow for Python builds. The most important changes are the addition of concurrency control and the inclusion of Python 3.13 in the test matrix.

Updates to GitHub Actions workflow:

* [`.github/workflows/python-build.yml`](diffhunk://#diff-e803f47b6d2d0403e24452eee3724d7eec3fa4bce8601474c779cdd231fa707eR27-R38): Added concurrency control to the `build` job to prevent multiple runs from the same group from executing simultaneously.
* [`.github/workflows/python-build.yml`](diffhunk://#diff-e803f47b6d2d0403e24452eee3724d7eec3fa4bce8601474c779cdd231fa707eR27-R38): Included Python 3.13 in the matrix of Python versions to test against.