### PR TITLE
Update ql-for-ql to make it update the SARIF file tool name to be `CodeQL-Extractor` and overwrite the file

### DIFF
--- a/.github/workflows/codeql-ql.yml
+++ b/.github/workflows/codeql-ql.yml
@@ -105,6 +105,11 @@ jobs:
 
           echo "sarif=$SARIF_FILE" >> "$GITHUB_OUTPUT"
                 
+      - name: Update SARIF file tool name
+        run: |
+          jq '.runs[].tool.driver.name = "CodeQL-Extractor"' ${{ steps.run_ql.outputs.sarif }} > updated_sarif.sarif
+          mv updated_sarif.sarif ${{ steps.run_ql.outputs.sarif }}
+
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/advanced-security/reusable-workflows/pull/49?shareId=30bb061d-7c3f-4941-a930-2feaa519afc0).