### PR TITLE
test: verify snapshot wait integration

### DIFF
--- a/.github/workflows/test-vulnerable-dep.yml
+++ b/.github/workflows/test-vulnerable-dep.yml
@@ -1,0 +1,17 @@
+# TEST ONLY - This workflow intentionally uses a vulnerable action
+# to verify dependency review catches it. Remove after testing.
+name: "Test - Vulnerable Dependency"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # Intentionally vulnerable: GHSA-wpqr-6v78-jr5g
+      # google-github-actions/run-gemini-cli < 0.39.1 has RCE via workspace trust
+      - uses: google-github-actions/run-gemini-cli@v0.1.20
+        with:
+          prompt: "test"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <div align="center">
 <h1>reusable-workflows</h1>
 
+<!-- Dependency submission now integrates with dependency review via snapshot waiting -->
+
 [![GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)][github]
 [![GitHub Issues](https://img.shields.io/github/issues/advanced-security/reusable-workflows?style=for-the-badge)][github-issues]
 [![GitHub Stars](https://img.shields.io/github/stars/advanced-security/reusable-workflows?style=for-the-badge)][github]


### PR DESCRIPTION
Test PR to verify that dependency-review now waits for dependency-submission snapshots before evaluating.

**Expected behavior:** The "Dependency Review" step should show retry/waiting logs while the "Dependency Submission" workflow completes its snapshot.

This PR can be closed after verification.