### PR TITLE
fix: resolve security review findings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,7 @@ jobs:
           VERSION_TAG: v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}
           MAJOR_TAG: v${{ steps.version.outputs.major }}
           MINOR_TAG: v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -115,7 +116,7 @@ jobs:
             git tag "$MINOR_TAG" --force
           fi
 
-          git push origin ${{ github.ref_name }}
+          git push origin "$REF_NAME"
           git push origin --tags --force
 
           # Create or update the release (supports promotion from prerelease)

--- a/.github/workflows/sec-opengrep.yml
+++ b/.github/workflows/sec-opengrep.yml
@@ -20,20 +20,36 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Download / Install Opengrep"
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -e
-          echo "[+] Fetching latest Opengrep release information"
-          API_URL="https://api.github.com/repos/opengrep/opengrep/releases/latest"
           ASSET_NAME="opengrep_manylinux_x86"
-          DOWNLOAD_URL=$(curl -s $API_URL | jq -r ".assets[] | select(.name==\"${ASSET_NAME}\") | .browser_download_url")
+
+          # Fetch latest release metadata and extract download URL + digest
+          RELEASE_JSON=$(gh api repos/opengrep/opengrep/releases/latest)
+          DOWNLOAD_URL=$(echo "$RELEASE_JSON" | jq -r ".assets[] | select(.name==\"${ASSET_NAME}\") | .browser_download_url")
+          EXPECTED_SHA=$(echo "$RELEASE_JSON" | jq -r ".assets[] | select(.name==\"${ASSET_NAME}\") | .digest" | sed 's/sha256://')
+          VERSION=$(echo "$RELEASE_JSON" | jq -r ".tag_name")
+
           if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" = "null" ]; then
-            echo "Could not find download URL for $ASSET_NAME"
+            echo "::error::Could not find download URL for $ASSET_NAME"
             exit 1
           fi
-          echo "[+] Downloading Opengrep from $DOWNLOAD_URL"
+
+          echo "[+] Downloading Opengrep ${VERSION} from $DOWNLOAD_URL"
           curl -sSfL -o "/usr/local/bin/opengrep" "$DOWNLOAD_URL"
+
+          # Verify integrity against API-reported digest
+          ACTUAL_SHA=$(sha256sum /usr/local/bin/opengrep | awk '{print $1}')
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::SHA256 mismatch! Expected: $EXPECTED_SHA, Got: $ACTUAL_SHA"
+            exit 1
+          fi
+          echo "[+] SHA256 verified: $ACTUAL_SHA"
+
           chmod +x /usr/local/bin/opengrep
-          echo "[+] Finished installing opengrep"
+          echo "[+] Finished installing opengrep ${VERSION}"
     
       - name: "Run Opengrep"
         run: opengrep scan --sarif-output ./results.sarif .


### PR DESCRIPTION
## Fixes

### 1. Script injection in release.yml (CodeQL alert #39)
Moved `github.ref_name` from direct expression interpolation in `run:` block to an `env:` variable. Prevents command injection via crafted branch names.

### 2. Supply chain hardening for sec-opengrep.yml
Still fetches the latest opengrep release (no version pin), but now **verifies the downloaded binary** against the SHA256 digest from the GitHub Releases API before execution. If the checksum doesn't match, the workflow fails.

Both findings from the security review (AI + CodeQL cross-reference).
