### PR TITLE
fix: include prereleases when resolving bump base version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,9 @@ jobs:
             exit 1
           fi
 
-          # Look up the highest semver release tag (including prereleases)
-          LATEST=$(gh api "/repos/$GITHUB_REPOSITORY/releases?per_page=100" \
-            --jq '[.[].tag_name | ltrimstr("v") | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+"))] | sort_by(split(".") | map(tonumber)) | last' \
+          # Look up the highest semver release tag (including prereleases, excluding drafts)
+          LATEST=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/releases" \
+            --jq '[.[] | select(.draft | not) | .tag_name | ltrimstr("v") | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort_by(split(".") | map(tonumber)) | last' \
             2>/dev/null || echo "")
           if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
             echo "::warning::No semver releases found. Defaulting to 0.1.0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,16 +53,17 @@ jobs:
             exit 1
           fi
 
-          # Look up latest release tag and increment
-          LATEST=$(gh api /repos/$GITHUB_REPOSITORY/releases/latest --jq '.tag_name' 2>/dev/null || echo "")
-          if [ -z "$LATEST" ]; then
-            echo "::warning::No existing releases found. Defaulting to 0.1.0"
+          # Look up the highest semver release tag (including prereleases)
+          LATEST=$(gh api "/repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+            --jq '[.[].tag_name | ltrimstr("v") | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+"))] | sort_by(split(".") | map(tonumber)) | last' \
+            2>/dev/null || echo "")
+          if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
+            echo "::warning::No semver releases found. Defaulting to 0.1.0"
             echo "version=0.1.0" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Strip leading 'v' if present
-          LATEST="${LATEST#v}"
+          echo "Latest semver release: $LATEST"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST"
 
           case "$INPUT_BUMP" in


### PR DESCRIPTION
## Problem

`bump: patch` failed on `dependabot-kev-action` because:
1. The only full release was `v0` (non-semver)
2. `v0.1.0` existed as a **prerelease** but `/releases/latest` API ignores prereleases
3. Parsing `v0` → `MAJOR=0, MINOR="", PATCH=""` → bump produced `0..1` (invalid semver)

## Fix

Replace `/releases/latest` with a query across **all releases** that:
- Includes prereleases
- Strips `v` prefix
- Filters to valid semver only (`X.Y.Z` pattern)
- Sorts and picks the highest version

Tested against `dependabot-kev-action` — correctly returns `0.1.0` (prerelease) instead of `0` (non-semver).
